### PR TITLE
[feat/10] 회원가입 커스텀 훅 및 React Hook Form 추가

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import useSignup from './useSignup';
 
 import Input from '@/components/Input/Input';
 import PasswordInput from '@/components/PasswordInput/PasswordInput';
 import Button from '@/components/Button/Button';
+import { InputErrorText } from '@/components/shared/inputErrorText';
 
 export default function SignupPage() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const test = 'hello';
+  const { register, handleSubmit, errors, isSubmitting, validation, setValue } =
+    useSignup();
 
   return (
     <div className='flex flex-col items-center gap-20 pt-20'>
@@ -25,25 +25,35 @@ export default function SignupPage() {
         />
       </Link>
 
-      <form className='w-full max-w-[500px] space-y-4'>
-        <Input
-          status='default'
-          placeholder='아이디를 입력하세요'
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          onClear={() => setUsername('')}
-        />
+      <form onSubmit={handleSubmit} className='w-full max-w-[500px]'>
+        <div className='mb-3'>
+          <Input
+            {...register('email', validation.email)}
+            placeholder='이메일을 입력하세요'
+            status={errors.email ? 'error' : 'default'}
+            onClear={() => setValue('email', '')}
+          />
+          <p className={InputErrorText()}>
+            {''}
+            {errors.email?.message || '\u00A0'}
+          </p>
+        </div>
 
-        <PasswordInput
-          status='default'
-          placeholder='비밀번호를 입력하세요'
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+        <div>
+          <PasswordInput
+            {...register('password', validation.password)}
+            placeholder='비밀번호를 입력하세요'
+            status={errors.password ? 'error' : 'default'}
+          />
+          <p className={InputErrorText()}>
+            {''}
+            {errors.password?.message || '\u00A0'}
+          </p>
+        </div>
 
-        <div className='pt-4'>
-          <Button type='submit' variant='primary'>
-            회원가입
+        <div className='pt-5'>
+          <Button type='submit' variant='primary' disabled={isSubmitting}>
+            {isSubmitting ? '처리 중...' : '회원가입'}
           </Button>
         </div>
 

--- a/app/(auth)/signup/useSignup.ts
+++ b/app/(auth)/signup/useSignup.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { AuthValidation } from '@/lib/validation/authValidation';
+
+interface SignupFormData {
+  email: string;
+  password: string;
+}
+
+export default function useSignup() {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<SignupFormData>({
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (data: SignupFormData) => {
+    try {
+      console.log('회원가입 데이터:', data);
+
+      // TODO: 나중에 API 호출
+    } catch (error) {
+      console.error('회원가입 실패', error);
+    }
+  };
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    setValue,
+    watch,
+    errors,
+    isSubmitting,
+    validation: AuthValidation,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "^16.0.7",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-hook-form": "^7.71.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -11726,6 +11727,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "^16.0.7",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hook-form": "^7.71.1",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { VariantProps } from 'class-variance-authority';
-
+import { forwardRef, useState } from 'react';
 import { cn } from '@/lib/cn';
 import { InputVariants } from '../shared/inputVariants';
 import DeleteIcon from '@/assets/icons/delete.svg';
@@ -12,32 +12,46 @@ type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
     onClear?: () => void;
   };
 
-export default function Input({
-  status,
-  className,
-  value,
-  onChange,
-  onClear,
-  ...props
-}: InputProps) {
-  return (
-    <div className='relative w-full'>
-      <input
-        {...props}
-        value={value}
-        onChange={onChange}
-        className={cn(InputVariants({ status }), className)}
-      />
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ status, className, onClear, ...props }, ref) => {
+    const [isActive, setIsActive] = useState(false);
+    const [hasText, setHasText] = useState(false);
 
-      {value && (
-        <button
-          type='button'
-          onClick={onClear}
-          className='absolute right-3 top-1/2 -translate-y-1/2 p-1 cursor-pointer'
-        >
-          <Image src={DeleteIcon} alt='삭제' width={20} height={20} />
-        </button>
-      )}
-    </div>
-  );
-}
+    return (
+      <div className='relative w-full'>
+        <input
+          ref={ref}
+          {...props}
+          onFocus={(e) => {
+            setIsActive(true);
+            props.onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setHasText(e.target.value.length > 0);
+            setIsActive(false);
+            props.onBlur?.(e);
+          }}
+          onChange={(e) => {
+            setHasText(e.target.value.length > 0);
+            props.onChange?.(e);
+          }}
+          className={cn(InputVariants({ status }), className)}
+        />
+
+        {isActive && hasText && onClear && (
+          <button
+            type='button'
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onClear}
+            className='absolute right-3 top-1/2 -translate-y-1/2 p-1 cursor-pointer'
+          >
+            <Image src={DeleteIcon} alt='삭제' width={20} height={20} />
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+export default Input;

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { VariantProps } from 'class-variance-authority';
 
 import { InputVariants } from '@/components/shared/inputVariants';
@@ -13,33 +13,35 @@ import EyesOnIcon from '@/assets/icons/eyes-on.svg';
 type PasswordInputProps = React.InputHTMLAttributes<HTMLInputElement> &
   VariantProps<typeof InputVariants>;
 
-export default function PasswordInput({
-  status,
-  className,
-  ...props
-}: PasswordInputProps) {
-  const [showPassword, setShowPassword] = useState(false);
+const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ status, className, ...props }, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
 
-  return (
-    <div className='relative w-full'>
-      <input
-        type={showPassword ? 'text' : 'password'}
-        {...props}
-        className={cn(InputVariants({ status }), 'pr-12', className)}
-      />
-
-      <button
-        type='button'
-        onClick={() => setShowPassword((prev) => !prev)}
-        className='absolute right-3 top-1/2 -translate-y-1/2 p-1 cursor-pointer'
-      >
-        <Image
-          src={showPassword ? EyesOnIcon : EyesOffIcon}
-          alt={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-          width={24}
-          height={24}
+    return (
+      <div className='relative w-full'>
+        <input
+          type={showPassword ? 'text' : 'password'}
+          ref={ref}
+          {...props}
+          className={cn(InputVariants({ status }), 'pr-12', className)}
         />
-      </button>
-    </div>
-  );
-}
+
+        <button
+          type='button'
+          onClick={() => setShowPassword((prev) => !prev)}
+          className='absolute right-3 top-1/2 -translate-y-1/2 p-1 cursor-pointer'
+        >
+          <Image
+            src={showPassword ? EyesOnIcon : EyesOffIcon}
+            alt={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+            width={24}
+            height={24}
+          />
+        </button>
+      </div>
+    );
+  },
+);
+
+PasswordInput.displayName = 'PasswordInput';
+export default PasswordInput;

--- a/src/components/shared/inputErrorText.ts
+++ b/src/components/shared/inputErrorText.ts
@@ -1,0 +1,3 @@
+import { cva } from 'class-variance-authority';
+
+export const InputErrorText = cva('mt-1 text-body2 text-red-20');

--- a/src/lib/validation/authValidation.ts
+++ b/src/lib/validation/authValidation.ts
@@ -1,0 +1,25 @@
+export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d)/;
+
+export const AuthValidation = {
+  email: {
+    required: '이메일을 입력해주세요',
+    pattern: {
+      value: EMAIL_PATTERN,
+      message: '이메일 형식이 올바르지 않습니다',
+    },
+  },
+
+  password: {
+    required: '비밀번호를 입력하세요',
+    minLength: {
+      value: 8,
+      message: '8자 이상 입력해주세요',
+    },
+
+    pattern: {
+      value: PASSWORD_PATTERN,
+      message: '영문과 숫자를 포함해야 합니다',
+    },
+  },
+};


### PR DESCRIPTION
# ✨ Pull Request Overview

## 🔥 목적(What & Why)

> 이 PR이 필요한 이유를 간단히 설명해주세요. (기능 추가/버그 수정/리팩토링/문서 작업 등)
- 회원가입 페이지의 폼 관리 및 유효성 검사를 위한 커스텀 훅과 React Hook Form 라이브러리를 추가합니다.

---

## 📌 변경 사항 (Changes)

- 주요 변경 내용 bullet list로 작성
- `useSignup` 커스텀 훅 구현
- 회원가입 폼 상태 관리
- 폼 제출 로직 처리
- 유효성 검사 로직 포함
- React Hook Form 라이브러리 추가 및 설정
- 회원가입 페이지에 훅 적용

---

## 🧪 테스트 및 확인 사항(Test Checklist)

- [x] 기능 정상 동작 확인
- [x] 크로스 브라우징 확인 (Chrome/Safari/Edge 등)
- [x] UI 깨짐 없는지 확인
- [x] 오류/경고 로그 없는지 확인
- [x] 영향받는 페이지/기능 연계 확인
- [x] 로직 변경 시 기존 기능에 영향 없는지 확인

---

## 🖼 스크린샷 / 캡쳐(Optional)

UI/UX 변경 사항이 있다면 첨부해주세요  
_(Drag & Drop)_

---

## 🔗 관련 이슈

Closes # (or Related to #10 )

---

## 💬 기타 코멘트(Notes)

리뷰어가 참고하면 좋을 내용, 고민 포인트, 추후 개선 방향 등 자유롭게
