### PR TITLE
[refactor/74] 회원가입 비밀번호 확인 입력 UI 추가

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -10,8 +10,15 @@ import Button from '@/components/Button/Button';
 import { InputErrorText } from '@/components/shared/inputErrorText';
 
 export default function SignupPage() {
-  const { register, handleSubmit, errors, isSubmitting, validation, setValue } =
-    useSignup();
+  const {
+    register,
+    handleSubmit,
+    errors,
+    isSubmitting,
+    validation,
+    setValue,
+    password,
+  } = useSignup();
 
   return (
     <div className='flex flex-col items-center gap-20 pt-20'>
@@ -34,20 +41,33 @@ export default function SignupPage() {
             onClear={() => setValue('email', '')}
           />
           <p className={InputErrorText()}>
-            {''}
             {errors.email?.message || '\u00A0'}
           </p>
         </div>
 
-        <div>
+        <div className='mb-3'>
+          {' '}
           <PasswordInput
             {...register('password', validation.password)}
             placeholder='비밀번호를 입력하세요'
             status={errors.password ? 'error' : 'default'}
           />
           <p className={InputErrorText()}>
-            {''}
             {errors.password?.message || '\u00A0'}
+          </p>
+        </div>
+
+        <div className='mb-3'>
+          <PasswordInput
+            {...register(
+              'passwordConfirm',
+              validation.passwordConfirm(password),
+            )}
+            placeholder='비밀번호를 다시 입력하세요'
+            status={errors.passwordConfirm ? 'error' : 'default'}
+          />
+          <p className={InputErrorText()}>
+            {errors.passwordConfirm?.message || '\u00A0'}
           </p>
         </div>
 
@@ -58,7 +78,7 @@ export default function SignupPage() {
         </div>
 
         <p className='flex items-center justify-center pt-4'>
-          <span className='text-body1'>회원이 아니신가요?</span>
+          <span className='text-body1'>회원이신가요?</span>
           <Link href='/login' className='pl-3 text-body1 bold text-blue-20'>
             로그인하기
           </Link>

--- a/app/(auth)/signup/useSignup.ts
+++ b/app/(auth)/signup/useSignup.ts
@@ -6,6 +6,7 @@ import { AuthValidation } from '@/lib/validation/authValidation';
 interface SignupFormData {
   email: string;
   password: string;
+  passwordConfirm: string;
 }
 
 export default function useSignup() {
@@ -18,6 +19,8 @@ export default function useSignup() {
   } = useForm<SignupFormData>({
     mode: 'onChange',
   });
+
+  const password = watch('password');
 
   const onSubmit = async (data: SignupFormData) => {
     try {
@@ -37,5 +40,6 @@ export default function useSignup() {
     errors,
     isSubmitting,
     validation: AuthValidation,
+    password,
   };
 }

--- a/src/lib/validation/authValidation.ts
+++ b/src/lib/validation/authValidation.ts
@@ -22,4 +22,10 @@ export const AuthValidation = {
       message: '영문과 숫자를 포함해야 합니다',
     },
   },
+
+  passwordConfirm: (password: string) => ({
+    required: '비밀번호를 다시 입력해주세요',
+    validate: (value: string) =>
+      value === password || '비밀번호가 일치하지 않습니다',
+  }),
 };


### PR DESCRIPTION
# ✨ Pull Request Overview

## 🔥 목적(What & Why)

> 이 PR이 필요한 이유를 간단히 설명해주세요. (기능 추가/버그 수정/리팩토링/문서 작업 등)
- 회원가입 시 비밀번호 오입력을 줄이고, 사용자가 입력한 비밀번호를 한 번 더 확인할 수 있도록 비밀번호 확인 입력 필드 UI를 추가했습니다.
기존에는 비밀번호 단일 입력만 제공되어 입력 실수를 사전에 방지하기 어려운 구조였습니다.

---

## 📌 변경 사항 (Changes)

- 주요 변경 내용 bullet list로 작성
- 회원가입 폼에 비밀번호 확인 입력 필드 UI 추가
- 비밀번호 / 비밀번호 확인 필드 레이아웃 및 스타일 정렬
- 기존 Input / PasswordInput 컴포넌트 재사용 구조 유지

---

## 🧪 테스트 및 확인 사항(Test Checklist)

- [x] 기능 정상 동작 확인
- [x] 크로스 브라우징 확인 (Chrome/Safari/Edge 등)
- [x] UI 깨짐 없는지 확인
- [x] 오류/경고 로그 없는지 확인
- [x] 영향받는 페이지/기능 연계 확인
- [x] 로직 변경 시 기존 기능에 영향 없는지 확인

---

## 🖼 스크린샷 / 캡쳐(Optional)

UI/UX 변경 사항이 있다면 첨부해주세요  
_(Drag & Drop)_

---

## 🔗 관련 이슈

Closes # (or Related to #74 )

---

## 💬 기타 코멘트(Notes)

리뷰어가 참고하면 좋을 내용, 고민 포인트, 추후 개선 방향 등 자유롭게
